### PR TITLE
refactor: ローカルdevサーバーをダミーデータ化・cloudflared削除

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,3 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-
-  cloudflared:
-    image: cloudflare/cloudflared:latest
-    command: tunnel --config /etc/cloudflared/config.yml run
-    user: "1000"
-    volumes:
-      - ${CLOUDFLARED_DIR}:/etc/cloudflared:ro
-    restart: unless-stopped
-    profiles:
-      - disabled

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,6 @@ services:
     restart: unless-stopped
     ports:
       - "8080:8080"
-    volumes:
-      - ./data:/app/data
-    environment:
-      - DB_PATH=/app/data/ev_data.db
 
   cloudflared:
     image: cloudflare/cloudflared:latest

--- a/server.py
+++ b/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-努力値トラッカー - サーバー
+努力値トラッカー - devサーバー（ダミーデータ返却）
 標準ライブラリのみ使用（追加インストール不要）
 """
 
@@ -9,40 +9,20 @@ import hashlib
 import http.server
 import json
 import os
-import sqlite3
 import sys
 from pathlib import Path
 
 PORT = int(os.environ.get("PORT", 8080))
-DB_PATH = Path(os.environ.get("DB_PATH", Path(__file__).parent / "ev_data.db"))
 _dist = Path(__file__).parent / "dist"
 STATIC_DIR = _dist if _dist.is_dir() else Path(__file__).parent
 
-
-def init_db():
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute("""
-            CREATE TABLE IF NOT EXISTS ev_data (
-                id    INTEGER PRIMARY KEY CHECK (id = 1),
-                data  TEXT NOT NULL
-            )
-        """)
-        conn.commit()
-
-
-def load_data():
-    with sqlite3.connect(DB_PATH) as conn:
-        row = conn.execute("SELECT data FROM ev_data WHERE id = 1").fetchone()
-        return json.loads(row[0]) if row else {}
-
-
-def save_data(data: dict):
-    with sqlite3.connect(DB_PATH) as conn:
-        conn.execute("""
-            INSERT INTO ev_data (id, data) VALUES (1, ?)
-            ON CONFLICT(id) DO UPDATE SET data = excluded.data
-        """, (json.dumps(data, ensure_ascii=False),))
-        conn.commit()
+DUMMY_DATA = {
+    "party": [], "allEVs": {}, "allIVs": {}, "allMoves": {},
+    "selected": None, "activeParty": [], "archivedParty": [],
+    "checkedItems": {}, "captureCount": 0, "captureGoals": [],
+    "todoList": [], "macho": False, "gakushuu": False, "gakushuuMon": None,
+    "trainerBattleCounts": {}
+}
 
 
 class Handler(http.server.BaseHTTPRequestHandler):
@@ -87,11 +67,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
         }.get(file_path.suffix, "application/octet-stream")
         raw_body = file_path.read_bytes()
         etag = f'"{hashlib.md5(raw_body).hexdigest()}"'
-        # Vite がハッシュを付与するアセット（dist/assets/*）は長期キャッシュ可
         is_hashed_asset = file_path.parent == STATIC_DIR / "assets"
         cache_control = "public, max-age=31536000, immutable" if is_hashed_asset else "no-cache"
 
-        # ETagが一致すれば 304 を返してボディ送信をスキップ
         if self.headers.get("If-None-Match") == etag:
             self.send_response(304)
             self.send_header("ETag", etag)
@@ -118,7 +96,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path == "/api/data":
-            self.send_json(200, load_data())
+            self.send_json(200, DUMMY_DATA)
         else:
             self._serve_static(self.path)
 
@@ -127,8 +105,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length)
             try:
-                data = json.loads(body)
-                save_data(data)
+                json.loads(body)
                 self.send_json(200, {"ok": True})
             except json.JSONDecodeError:
                 self.send_json(400, {"error": "invalid JSON"})
@@ -137,9 +114,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
 
 if __name__ == "__main__":
-    init_db()
     server = http.server.ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
-    print(f"サーバー起動: http://localhost:{PORT}")
+    print(f"devサーバー起動: http://localhost:{PORT}")
     print(f"LAN内からは: http://<このPCのIP>:{PORT}")
     print("停止: Ctrl+C")
     try:

--- a/test_server.py
+++ b/test_server.py
@@ -8,73 +8,15 @@ import gzip
 import http.client
 import http.server
 import json
-import os
 import sys
-import tempfile
 import threading
 import unittest
 import urllib.error
 import urllib.request
 from pathlib import Path
-from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 import server
-
-
-# ---------------------------------------------------------------------------
-# DB ユニットテスト
-# ---------------------------------------------------------------------------
-
-class TestDatabase(unittest.TestCase):
-    """init_db / load_data / save_data のユニットテスト"""
-
-    def setUp(self):
-        fd, path = tempfile.mkstemp(suffix=".db")
-        os.close(fd)
-        self.db_path = Path(path)
-
-    def tearDown(self):
-        self.db_path.unlink(missing_ok=True)
-
-    def test_load_empty_db_returns_empty_dict(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            self.assertEqual(server.load_data(), {})
-
-    def test_save_and_load_roundtrip(self):
-        data = {
-            "party": [{"name": "リザードン", "icon": "🔥", "color": "#FF6B35"}],
-            "allEVs": {
-                "リザードン": {"hp": 0, "atk": 252, "def": 0, "spa": 252, "spd": 0, "spe": 4}
-            },
-            "selected": "リザードン",
-        }
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(data)
-            self.assertEqual(server.load_data(), data)
-
-    def test_save_overwrites_existing(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data({"selected": "A"})
-            server.save_data({"selected": "B"})
-            self.assertEqual(server.load_data()["selected"], "B")
-
-    def test_unicode_preserved(self):
-        data = {"selected": "ピカチュウ", "note": "てすと"}
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(data)
-            self.assertEqual(server.load_data(), data)
-
-    def test_init_db_is_idempotent(self):
-        """init_db() を複数回呼んでもエラーにならない"""
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.init_db()
-            self.assertEqual(server.load_data(), {})
 
 
 # ---------------------------------------------------------------------------
@@ -86,14 +28,6 @@ class TestHTTPServer(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        fd, path = tempfile.mkstemp(suffix=".db")
-        os.close(fd)
-        cls.db_path = Path(path)
-
-        cls._patcher = patch.object(server, "DB_PATH", cls.db_path)
-        cls._patcher.start()
-        server.init_db()
-
         cls.httpd = http.server.HTTPServer(("127.0.0.1", 0), server.Handler)
         cls.port = cls.httpd.server_address[1]
         cls._thread = threading.Thread(target=cls.httpd.serve_forever)
@@ -103,8 +37,6 @@ class TestHTTPServer(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls.httpd.shutdown()
-        cls._patcher.stop()
-        cls.db_path.unlink(missing_ok=True)
 
     def url(self, path):
         return f"http://127.0.0.1:{self.port}{path}"
@@ -129,6 +61,13 @@ class TestHTTPServer(unittest.TestCase):
         with urllib.request.urlopen(self.url("/api/data")) as res:
             self.assertEqual(res.headers.get("Access-Control-Allow-Origin"), "*")
 
+    def test_get_api_data_returns_dummy_data(self):
+        with urllib.request.urlopen(self.url("/api/data")) as res:
+            body = json.loads(res.read())
+        self.assertIn("party", body)
+        self.assertIn("allEVs", body)
+        self.assertIsInstance(body["party"], list)
+
     # --- POST /api/data ---
 
     def test_post_valid_json_returns_ok(self):
@@ -143,19 +82,6 @@ class TestHTTPServer(unittest.TestCase):
             self.assertEqual(res.status, 200)
             body = json.loads(res.read())
         self.assertTrue(body.get("ok"))
-
-    def test_post_then_get_reflects_saved_data(self):
-        data = {"party": [], "allEVs": {}, "selected": "ゲンガー"}
-        req = urllib.request.Request(
-            self.url("/api/data"),
-            data=json.dumps(data).encode(),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        urllib.request.urlopen(req).close()
-        with urllib.request.urlopen(self.url("/api/data")) as res:
-            saved = json.loads(res.read())
-        self.assertEqual(saved["selected"], "ゲンガー")
 
     def test_post_invalid_json_returns_400(self):
         req = urllib.request.Request(
@@ -466,9 +392,7 @@ class TestEVRules(unittest.TestCase):
         self.assertEqual(result["spe"], 4)
 
     def test_remaining_budget_correctly_limits_addition(self):
-        # 残り6しか入らない状況で10振ろうとする
         evs = {**self._zero_evs(), "hp": 252, "atk": 252, "def": 0, "spa": 0, "spd": 0, "spe": 0}
-        # total=504, remaining=6
         result = self._change(evs, "def", 10)
         self.assertEqual(result["def"], 6)
         self.assertEqual(sum(result.values()), self.MAX_TOTAL)
@@ -515,12 +439,10 @@ class TestMachoBrace(unittest.TestCase):
         return {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
 
     def test_plus1_becomes_plus2_with_macho(self):
-        # ＋ボタン(d=1) → ×2 → +2
         evs = self._change(self._zero_evs(), "hp", 1, macho=True)
         self.assertEqual(evs["hp"], 2)
 
     def test_plus4_becomes_plus8_with_macho(self):
-        # ＋4ボタン(d=4) → ×2 → +8
         evs = self._change(self._zero_evs(), "hp", 4, macho=True)
         self.assertEqual(evs["hp"], 8)
 
@@ -536,12 +458,12 @@ class TestMachoBrace(unittest.TestCase):
 
     def test_macho_still_caps_at_252(self):
         evs = {**self._zero_evs(), "hp": 248}
-        result = self._change(evs, "hp", 4, macho=True)  # +8 → capped at 252
+        result = self._change(evs, "hp", 4, macho=True)
         self.assertEqual(result["hp"], 252)
 
     def test_macho_still_caps_at_510_total(self):
         evs = {**self._zero_evs(), "hp": 252, "atk": 252, "def": 4}
-        result = self._change(evs, "spa", 4, macho=True)  # total=508, +8 → capped
+        result = self._change(evs, "spa", 4, macho=True)
         self.assertLessEqual(sum(result.values()), self.MAX_TOTAL)
 
     def test_without_macho_plus4_is_4(self):
@@ -561,7 +483,6 @@ class TestMachoBrace(unittest.TestCase):
 class TestVitamins(unittest.TestCase):
 
     def setUp(self):
-        # シンプルな実装で再定義
         import math
         self._vl = lambda ev: math.ceil((100 - ev) / 10) if ev < 100 else 0
 
@@ -569,7 +490,6 @@ class TestVitamins(unittest.TestCase):
         self.assertEqual(self._vl(0), 10)
 
     def test_4ev_can_use_10_vitamins(self):
-        # 4→14→24→…→94→104, 94<100なので10本使える
         self.assertEqual(self._vl(4), 10)
 
     def test_95ev_can_use_1_vitamin(self):
@@ -588,175 +508,22 @@ class TestVitamins(unittest.TestCase):
         self.assertEqual(self._vl(89), 2)
 
     def test_1ev_can_use_10_vitamins(self):
-        # ceil((100-1)/10) = ceil(9.9) = 10
         self.assertEqual(self._vl(1), 10)
 
     def test_50ev_can_use_5_vitamins(self):
-        # ceil((100-50)/10) = ceil(5.0) = 5
         self.assertEqual(self._vl(50), 5)
 
     def test_99ev_can_use_1_vitamin(self):
-        # ceil((100-99)/10) = ceil(0.1) = 1
         self.assertEqual(self._vl(99), 1)
 
     def test_91ev_can_use_1_vitamin(self):
-        # ceil((100-91)/10) = ceil(0.9) = 1
         self.assertEqual(self._vl(91), 1)
 
     def test_10ev_can_use_9_vitamins(self):
-        # ceil((100-10)/10) = ceil(9.0) = 9
         self.assertEqual(self._vl(10), 9)
 
     def test_9ev_can_use_10_vitamins(self):
-        # ceil((100-9)/10) = ceil(9.1) = 10
         self.assertEqual(self._vl(9), 10)
-
-
-# ---------------------------------------------------------------------------
-# メモ欄: DB保存テスト（party に memo フィールドが保存・復元される）
-# ---------------------------------------------------------------------------
-
-class TestMemo(unittest.TestCase):
-
-    def setUp(self):
-        fd, path = tempfile.mkstemp(suffix=".db")
-        os.close(fd)
-        self.db_path = Path(path)
-
-    def tearDown(self):
-        self.db_path.unlink(missing_ok=True)
-
-    def test_memo_saved_and_loaded(self):
-        data = {
-            "party": [{"name": "ゲンガー", "icon": "👻", "color": "#C97AE0", "memo": "おくびょう　めがねゲンガー"}],
-            "allEVs": {"ゲンガー": {"hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252}},
-            "selected": "ゲンガー",
-        }
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(data)
-            result = server.load_data()
-        self.assertEqual(result["party"][0]["memo"], "おくびょう　めがねゲンガー")
-
-    def test_empty_memo_preserved(self):
-        data = {
-            "party": [{"name": "リザードン", "icon": "🔥", "color": "#FF6B35", "memo": ""}],
-            "allEVs": {"リザードン": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}},
-            "selected": "リザードン",
-        }
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(data)
-            result = server.load_data()
-        self.assertEqual(result["party"][0]["memo"], "")
-
-    def test_memo_updated(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data({"party": [{"name": "A", "memo": "before"}], "allEVs": {}, "selected": "A"})
-            server.save_data({"party": [{"name": "A", "memo": "after"}],  "allEVs": {}, "selected": "A"})
-            result = server.load_data()
-        self.assertEqual(result["party"][0]["memo"], "after")
-
-
-# ---------------------------------------------------------------------------
-# パーティメンバー拡張フィールドのテスト（nature / dexId / allMoves）
-# ---------------------------------------------------------------------------
-
-class TestExtendedFields(unittest.TestCase):
-    """第3世代追加フィールド（性格・図鑑番号・技セット）の保存・復元テスト"""
-
-    def setUp(self):
-        fd, path = tempfile.mkstemp(suffix=".db")
-        os.close(fd)
-        self.db_path = Path(path)
-
-    def tearDown(self):
-        self.db_path.unlink(missing_ok=True)
-
-    def _full_data(self):
-        return {
-            "party": [
-                {
-                    "name":   "ゲンガー",
-                    "icon":   "👻",
-                    "color":  "#C97AE0",
-                    "memo":   "おくびょう　めがね",
-                    "nature": "おくびょう",
-                    "dexId":  93,
-                }
-            ],
-            "allEVs": {
-                "ゲンガー": {"hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252}
-            },
-            "allMoves": {
-                "ゲンガー": ["シャドーボール", "サイコキネシス", "でんじは", ""]
-            },
-            "selected": "ゲンガー",
-        }
-
-    def test_nature_field_preserved(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(self._full_data())
-            result = server.load_data()
-        self.assertEqual(result["party"][0]["nature"], "おくびょう")
-
-    def test_dex_id_field_preserved(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(self._full_data())
-            result = server.load_data()
-        self.assertEqual(result["party"][0]["dexId"], 93)
-
-    def test_all_moves_preserved(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(self._full_data())
-            result = server.load_data()
-        self.assertEqual(result["allMoves"]["ゲンガー"], ["シャドーボール", "サイコキネシス", "でんじは", ""])
-
-    def test_empty_move_slot_preserved(self):
-        """空文字列の技スロットがそのまま返ること"""
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(self._full_data())
-            result = server.load_data()
-        self.assertEqual(result["allMoves"]["ゲンガー"][3], "")
-
-    def test_multiple_party_members(self):
-        data = {
-            "party": [
-                {"name": "ピカチュウ", "icon": "⚡", "color": "#F5D020", "memo": "", "nature": "ようき", "dexId": 24},
-                {"name": "リザードン", "icon": "🔥", "color": "#FF6B35", "memo": "", "nature": "ひかえめ", "dexId": 5},
-            ],
-            "allEVs": {
-                "ピカチュウ": {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 4, "spe": 252},
-                "リザードン": {"hp": 0, "atk": 0, "def": 0, "spa": 252, "spd": 4, "spe": 252},
-            },
-            "allMoves": {
-                "ピカチュウ":  ["10まんボルト", "", "", ""],
-                "リザードン": ["だいもんじ", "かえんほうしゃ", "", ""],
-            },
-            "selected": "ピカチュウ",
-        }
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(data)
-            result = server.load_data()
-        self.assertEqual(len(result["party"]), 2)
-        self.assertEqual(result["party"][1]["nature"], "ひかえめ")
-        self.assertEqual(result["allMoves"]["リザードン"][0], "だいもんじ")
-
-    def test_update_moves_overwrites_correctly(self):
-        with patch.object(server, "DB_PATH", self.db_path):
-            server.init_db()
-            server.save_data(self._full_data())
-            updated = self._full_data()
-            updated["allMoves"]["ゲンガー"] = ["なみのり", "", "", ""]
-            server.save_data(updated)
-            result = server.load_data()
-        self.assertEqual(result["allMoves"]["ゲンガー"][0], "なみのり")
 
 
 if __name__ == "__main__":

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,13 +1,32 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      "/api": "http://localhost:8080",
+const DUMMY_DATA = {
+  party: [], allEVs: {}, allIVs: {}, allMoves: {},
+  selected: null, activeParty: [], archivedParty: [],
+  checkedItems: {}, captureCount: 0, captureGoals: [],
+  todoList: [], macho: false, gakushuu: false, gakushuuMon: null,
+  trainerBattleCounts: {}
+};
+
+function apiMockPlugin() {
+  return {
+    name: "api-mock",
+    configureServer(server) {
+      server.middlewares.use("/api/data", (req, res) => {
+        res.setHeader("Content-Type", "application/json");
+        if (req.method === "GET") {
+          res.end(JSON.stringify(DUMMY_DATA));
+        } else {
+          res.end(JSON.stringify({ ok: true }));
+        }
+      });
     },
-  },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), apiMockPlugin()],
   build: {
     outDir: "dist",
     assetsDir: "assets",


### PR DESCRIPTION
## Summary

- `server.py` の SQLite 依存を削除し、固定ダミーデータを返す stateless な dev サーバーに変更
- `vite.config.js` のプロキシ設定を削除し、Vite インライン mock プラグインに置き換え
- `docker-compose.yml` から `volumes`・`DB_PATH` 環境変数・`cloudflared` サービスを削除
- `test_server.py` から DB 系テストクラス（TestDatabase・TestMemo・TestExtendedFields）を削除

本番が Cloudflare Pages + D1 に移行済みのため、ローカルはシンプルな動作確認用 dev サーバーに整理。

## Test plan

- [x] `python3 test_server.py` → 66テスト全パス
- [x] `npm run test:e2e` → 15テスト全パス
- [x] `curl http://localhost:8080/api/data` → ダミー JSON が返ること確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)