### PR TITLE
fix: ダミーデータ空パーティによる空白ページを修正

### DIFF
--- a/server.py
+++ b/server.py
@@ -16,9 +16,25 @@ PORT = int(os.environ.get("PORT", 8080))
 _dist = Path(__file__).parent / "dist"
 STATIC_DIR = _dist if _dist.is_dir() else Path(__file__).parent
 
+_DEFAULT_PARTY = [
+    {"name": "リザードン", "icon": "🔥", "color": "#FF6B35", "memo": "", "nature": "", "dexId": 5},
+    {"name": "ガラガラ",   "icon": "💀", "color": "#A0A0A0", "memo": "", "nature": "", "dexId": 104},
+    {"name": "ギャラドス", "icon": "🌊", "color": "#4A90D9", "memo": "", "nature": "", "dexId": 129},
+    {"name": "カビゴン",   "icon": "😴", "color": "#7DBE8A", "memo": "", "nature": "", "dexId": 142},
+    {"name": "サンダー",   "icon": "⚡", "color": "#F5D020", "memo": "", "nature": "", "dexId": 144},
+    {"name": "ルージュラ", "icon": "💋", "color": "#E880A0", "memo": "", "nature": "", "dexId": 123},
+]
+_ZERO_EVS = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+_MAX_IVS  = {"hp": 31, "atk": 31, "def": 31, "spa": 31, "spd": 31, "spe": 31}
+
 DUMMY_DATA = {
-    "party": [], "allEVs": {}, "allIVs": {}, "allMoves": {},
-    "selected": None, "activeParty": [], "archivedParty": [],
+    "party":    _DEFAULT_PARTY,
+    "allEVs":   {p["name"]: {**_ZERO_EVS} for p in _DEFAULT_PARTY},
+    "allIVs":   {p["name"]: {**_MAX_IVS}  for p in _DEFAULT_PARTY},
+    "allMoves": {p["name"]: ["", "", "", ""] for p in _DEFAULT_PARTY},
+    "selected": _DEFAULT_PARTY[0]["name"],
+    "activeParty": [None, None, None, None, None, None],
+    "archivedParty": [],
     "checkedItems": {}, "captureCount": 0, "captureGoals": [],
     "todoList": [], "macho": False, "gakushuu": False, "gakushuuMon": None,
     "trainerBattleCounts": {}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,26 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+const DEFAULT_PARTY = [
+  { name: "リザードン", icon: "🔥", color: "#FF6B35", memo: "", nature: "", dexId: 5 },
+  { name: "ガラガラ",   icon: "💀", color: "#A0A0A0", memo: "", nature: "", dexId: 104 },
+  { name: "ギャラドス", icon: "🌊", color: "#4A90D9", memo: "", nature: "", dexId: 129 },
+  { name: "カビゴン",   icon: "😴", color: "#7DBE8A", memo: "", nature: "", dexId: 142 },
+  { name: "サンダー",   icon: "⚡", color: "#F5D020", memo: "", nature: "", dexId: 144 },
+  { name: "ルージュラ", icon: "💋", color: "#E880A0", memo: "", nature: "", dexId: 123 },
+];
+const zeroEVs = { hp: 0, atk: 0, def: 0, spa: 0, spd: 0, spe: 0 };
+const maxIVs  = { hp: 31, atk: 31, def: 31, spa: 31, spd: 31, spe: 31 };
+const fromEntries = (arr, fn) => Object.fromEntries(arr.map(p => [p.name, fn(p)]));
+
 const DUMMY_DATA = {
-  party: [], allEVs: {}, allIVs: {}, allMoves: {},
-  selected: null, activeParty: [], archivedParty: [],
+  party:    DEFAULT_PARTY,
+  allEVs:   fromEntries(DEFAULT_PARTY, () => ({ ...zeroEVs })),
+  allIVs:   fromEntries(DEFAULT_PARTY, () => ({ ...maxIVs })),
+  allMoves: fromEntries(DEFAULT_PARTY, () => ["", "", "", ""]),
+  selected: DEFAULT_PARTY[0].name,
+  activeParty: [null, null, null, null, null, null],
+  archivedParty: [],
   checkedItems: {}, captureCount: 0, captureGoals: [],
   todoList: [], macho: false, gakushuu: false, gakushuuMon: null,
   trainerBattleCounts: {}


### PR DESCRIPTION
## Summary

- ダミーデータの `party: []` + `selected: null` の組み合わせにより、アプリが存在しないポケモンを参照してクラッシュしていた
- `data-pokemon.js` の `DEFAULT_PARTY`（リザードン等6匹）と同内容をダミーデータに設定

## Test plan

- [x] `curl http://localhost:8080/api/data` → 6匹のパーティが返ること確認済み
- [x] `python3 test_server.py` → 66テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)