### PR TITLE
feat: devサーバー時に左下DEVバッジを表示

### DIFF
--- a/js/tracker.jsx
+++ b/js/tracker.jsx
@@ -39,6 +39,7 @@ export default function EVTracker() {
   const [allMoves,  setAllMoves] = useState(() => Object.fromEntries(DEFAULT_PARTY.map(p => [p.name, ["","","",""]])));
   const [selected,  setSelected] = useState(DEFAULT_PARTY[0].name);
   const [loaded,       setLoaded]       = useState(false);
+  const [isDev,        setIsDev]        = useState(false);
   const [macho,        setMacho]        = useState(false);
   const [gakushuu,     setGakushuu]     = useState(false);
   const [gakushuuMon,  setGakushuuMon]  = useState(null);
@@ -224,6 +225,7 @@ export default function EVTracker() {
           setActiveParty([...ap, null, null, null, null, null, null].slice(0, 6));
         }
         if (saved.archivedParty) setArchivedParty(saved.archivedParty);
+        if (saved._dev)                setIsDev(true);
         if (saved.macho != null)       setMacho(saved.macho);
         if (saved.gakushuu != null)    setGakushuu(saved.gakushuu);
         if (saved.gakushuuMon != null) setGakushuuMon(saved.gakushuuMon);
@@ -739,6 +741,10 @@ export default function EVTracker() {
           )}
         </div>
       </div>
+
+      {isDev && (
+        <div style={{ position: "fixed", bottom: "56px", left: "8px", fontSize: "9px", color: "#444", background: "#111", border: "1px solid #333", borderRadius: "3px", padding: "2px 5px", letterSpacing: "1px", fontFamily: "monospace", zIndex: 101 }}>DEV</div>
+      )}
 
       {/* Bottom nav（モバイルのみ） */}
       <nav className="bottom-nav">

--- a/server.py
+++ b/server.py
@@ -37,7 +37,7 @@ DUMMY_DATA = {
     "archivedParty": [],
     "checkedItems": {}, "captureCount": 0, "captureGoals": [],
     "todoList": [], "macho": False, "gakushuu": False, "gakushuuMon": None,
-    "trainerBattleCounts": {}
+    "trainerBattleCounts": {}, "_dev": True
 }
 
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,7 @@ const DUMMY_DATA = {
   archivedParty: [],
   checkedItems: {}, captureCount: 0, captureGoals: [],
   todoList: [], macho: false, gakushuu: false, gakushuuMon: null,
-  trainerBattleCounts: {}
+  trainerBattleCounts: {}, _dev: true
 };
 
 function apiMockPlugin() {


### PR DESCRIPTION
## Summary

- `server.py` と `vite.config.js` のダミーデータに `_dev: true` フラグを追加
- フロントエンドが `_dev` を検知したら左下に `DEV` バッジを固定表示
- 本番（Cloudflare）はフラグなし → バッジ非表示

## Test plan

- [x] `python3 test_server.py` → 66テスト全パス
- [x] `curl /api/data` → `_dev: true` 確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)