### PR TITLE
fix: iPhoneホーム画面PWAアイコンが表示されない問題を修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DotGothic16&display=swap">
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>👾</text></svg>">
-    <link rel="apple-touch-icon" href="/icon-pixel.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/icon-pixel.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="ポケログ">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,13 +12,13 @@
       "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- `apple-touch-icon`に`sizes="180x180"`を追加（サイズ明示でiOSがアイコンを確実に選択するように）
- `manifest.json`のicons `purpose`を`"any maskable"`→`"any"`に変更（maskable指定によるiOS 80%セーフゾーンクリッピングを回避）

## 根本原因

iOS 15.4+はWeb App Manifestを読むようになり、`maskable`指定があるとアイコン中央80%のセーフゾーンのみを表示するマスクが適用される。現在のポケボールアイコンはデザインがエッジ付近まで伸びているため、マスクで大幅に切り取られてほぼ表示されない状態になっていた。

## Test plan

- [ ] iPhoneのSafariでサイトにアクセス → 共有ボタン → 「ホーム画面に追加」
- [ ] ホーム画面にピクセルアートポケボールアイコンが表示されることを確認

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)