### PR TITLE
perf: iPhoneホーム画面起動の高速化

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,5 +18,10 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js');
+      }
+    </script>
   </body>
 </html>

--- a/js/tracker.jsx
+++ b/js/tracker.jsx
@@ -203,32 +203,47 @@ export default function EVTracker() {
   }, []);
 
   useEffect(() => {
+    const applyData = (saved) => {
+      if (saved.party)        setParty(saved.party.map(p => {
+        if (p.dexId != null) return p;
+        const idx = POKEMON_DATA.findIndex(pd => pd[1] === p.name);
+        return { ...p, dexId: idx >= 0 ? idx : null };
+      }));
+      if (saved.allEVs)       setAllEVs(saved.allEVs);
+      if (saved.allIVs)       setAllIVs(saved.allIVs);
+      if (saved.allMoves)     setAllMoves(saved.allMoves);
+      if (saved.selected)     setSelected(saved.selected);
+      if (saved.checkedItems)        setCheckedItems(saved.checkedItems);
+      if (saved.trainerBattleCounts) setTrainerBattleCounts(saved.trainerBattleCounts);
+      if (saved.captureCount != null) setCaptureCount(saved.captureCount);
+      if (saved.captureGoals)  setCaptureGoals(saved.captureGoals);
+      if (saved.todoList)      setTodoList(saved.todoList);
+      if (saved.activeParty) {
+        const ap = saved.activeParty;
+        setActiveParty([...ap, null, null, null, null, null, null].slice(0, 6));
+      }
+      if (saved.archivedParty) setArchivedParty(saved.archivedParty);
+      if (saved._dev)                setIsDev(true);
+      if (saved.macho != null)       setMacho(saved.macho);
+      if (saved.gakushuu != null)    setGakushuu(saved.gakushuu);
+      if (saved.gakushuuMon != null) setGakushuuMon(saved.gakushuuMon);
+    };
+
+    // ① localStorage に前回データがあれば即座に表示
+    const cached = localStorage.getItem('pokelog-data');
+    if (cached) {
+      try {
+        applyData(JSON.parse(cached));
+        setLoaded(true);
+      } catch (e) {}
+    }
+
+    // ② バックグラウンドでサーバーと同期（最新データで上書き + キャッシュ更新）
     fetch("/api/data")
       .then(r => r.json())
       .then(saved => {
-        if (saved.party)        setParty(saved.party.map(p => {
-          if (p.dexId != null) return p;
-          const idx = POKEMON_DATA.findIndex(pd => pd[1] === p.name);
-          return { ...p, dexId: idx >= 0 ? idx : null };
-        }));
-        if (saved.allEVs)       setAllEVs(saved.allEVs);
-        if (saved.allIVs)       setAllIVs(saved.allIVs);
-        if (saved.allMoves)     setAllMoves(saved.allMoves);
-        if (saved.selected)     setSelected(saved.selected);
-        if (saved.checkedItems)        setCheckedItems(saved.checkedItems);
-        if (saved.trainerBattleCounts) setTrainerBattleCounts(saved.trainerBattleCounts);
-        if (saved.captureCount != null) setCaptureCount(saved.captureCount);
-        if (saved.captureGoals)  setCaptureGoals(saved.captureGoals);
-        if (saved.todoList)      setTodoList(saved.todoList);
-        if (saved.activeParty) {
-          const ap = saved.activeParty;
-          setActiveParty([...ap, null, null, null, null, null, null].slice(0, 6));
-        }
-        if (saved.archivedParty) setArchivedParty(saved.archivedParty);
-        if (saved._dev)                setIsDev(true);
-        if (saved.macho != null)       setMacho(saved.macho);
-        if (saved.gakushuu != null)    setGakushuu(saved.gakushuu);
-        if (saved.gakushuuMon != null) setGakushuuMon(saved.gakushuuMon);
+        applyData(saved);
+        localStorage.setItem('pokelog-data', JSON.stringify(saved));
       })
       .catch(() => {})
       .finally(() => setLoaded(true));

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,41 @@
+const CACHE = 'pokelog-v1';
+
+self.addEventListener('install', e => self.skipWaiting());
+
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', e => {
+  const { pathname } = new URL(e.request.url);
+
+  // API は常にネットワーク（キャッシュしない）
+  if (pathname.startsWith('/api/')) return;
+
+  // /assets/* はキャッシュファースト（ハッシュ付きファイル名で不変）
+  if (pathname.startsWith('/assets/')) {
+    e.respondWith(
+      caches.match(e.request).then(hit =>
+        hit || fetch(e.request).then(res => {
+          caches.open(CACHE).then(c => c.put(e.request, res.clone()));
+          return res;
+        })
+      )
+    );
+    return;
+  }
+
+  // index.html / manifest / icons: ネットワークファースト、失敗時はキャッシュから
+  e.respondWith(
+    fetch(e.request)
+      .then(res => {
+        caches.open(CACHE).then(c => c.put(e.request, res.clone()));
+        return res;
+      })
+      .catch(() => caches.match(e.request))
+  );
+});


### PR DESCRIPTION
## Summary

- `localStorage` に前回データをキャッシュし、起動時に "ロード中…" を表示せず即座に UI を表示する
- Service Worker (`public/sw.js`) を追加し、JS/CSS アセットをキャッシュファーストで配信（2回目以降はネットワーク不要）
- オフライン時もキャッシュデータで起動できるようになった

## Test plan

- [ ] iPhoneホーム画面から起動し、"ロード中…" が表示されず即座に UI が出ることを確認
- [ ] 2回目以降の起動が体感的に速いことを確認
- [ ] 機内モードで起動し、前回のデータが表示されることを確認
- [ ] データ変更後に再起動し、変更が反映されていることを確認（サーバー同期が機能している）
- [ ] Safari DevTools > Application > Service Workers で SW が登録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)