### PR TITLE
feat: ふたごじまをアイテムチェックリストに追加 + Service Worker によるPWA高速化

### DIFF
--- a/test_server.py
+++ b/test_server.py
@@ -68,6 +68,12 @@ class TestHTTPServer(unittest.TestCase):
         self.assertIn("allEVs", body)
         self.assertIsInstance(body["party"], list)
 
+    def test_get_api_data_has_checked_items_key(self):
+        with urllib.request.urlopen(self.url("/api/data")) as res:
+            body = json.loads(res.read())
+        self.assertIn("checkedItems", body)
+        self.assertIsInstance(body["checkedItems"], dict)
+
     # --- POST /api/data ---
 
     def test_post_valid_json_returns_ok(self):
@@ -80,6 +86,24 @@ class TestHTTPServer(unittest.TestCase):
         )
         with urllib.request.urlopen(req) as res:
             self.assertEqual(res.status, 200)
+            body = json.loads(res.read())
+        self.assertTrue(body.get("ok"))
+
+    def test_post_accepts_full_data_structure(self):
+        """CLAUDE.md に定義された全フィールドを含む JSON を POST できること"""
+        data = {
+            "party": [], "allEVs": {}, "allIVs": {}, "allMoves": {},
+            "selected": None, "activeParty": [None] * 6,
+            "checkedItems": {"ft01": True, "ft07": True},
+            "captureCount": 0, "captureGoals": [], "todoList": [],
+        }
+        req = urllib.request.Request(
+            self.url("/api/data"),
+            data=json.dumps(data).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as res:
             body = json.loads(res.read())
         self.assertTrue(body.get("ok"))
 
@@ -175,6 +199,29 @@ class TestHTTPServer(unittest.TestCase):
     def test_get_index_html_explicit(self):
         with urllib.request.urlopen(self.url("/index.html")) as res:
             self.assertEqual(res.status, 200)
+
+    def _sw_available(self):
+        return (server.STATIC_DIR / "sw.js").exists()
+
+    def test_get_sw_js_returns_200(self):
+        if not self._sw_available():
+            self.skipTest("dist/sw.js が見つかりません（Vite ビルド前）")
+        with urllib.request.urlopen(self.url("/sw.js")) as res:
+            self.assertEqual(res.status, 200)
+
+    def test_get_sw_js_content_type(self):
+        if not self._sw_available():
+            self.skipTest("dist/sw.js が見つかりません（Vite ビルド前）")
+        with urllib.request.urlopen(self.url("/sw.js")) as res:
+            self.assertIn("javascript", res.headers.get("Content-Type", ""))
+
+    def test_get_sw_js_cache_control_not_immutable(self):
+        """Service Worker は更新可能でなければならないため immutable キャッシュを設定しない"""
+        if not self._sw_available():
+            self.skipTest("dist/sw.js が見つかりません（Vite ビルド前）")
+        with urllib.request.urlopen(self.url("/sw.js")) as res:
+            cc = res.headers.get("Cache-Control", "")
+        self.assertNotIn("immutable", cc)
 
     def _asset_path(self, suffix):
         """dist/assets/ 内の指定拡張子のファイルパスを返す（Vite ビルド後）"""


### PR DESCRIPTION
## Summary

- ふたごじまエリア（B1F〜B4F）のアイテム7件をチェックリストに追加（フリーザーをハナダの洞窟から正しい場所へ移動）
- localStorageキャッシュによる初回表示の高速化（サーバー同期前にキャッシュを即時反映）
- Service Worker（`/sw.js`）を追加し、iPhoneホーム画面起動時の読み込みを改善
- 上記変更に対応したテストを `test_server.py` に5件追加

## Test plan

- [x] `python3 test_server.py` — 71テスト全通過（sw.js 系3件はビルド前のためスキップ）
- [x] `playwright test` — 15テスト全通過（pre-push フックで確認済み）
- [ ] `docker compose up -d --build` 後に `/sw.js` 系テストが PASS することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)