### PR TITLE
feat: 個体値チェッカーから育成パーティに直接登録

### DIFF
--- a/js/components-chosa.jsx
+++ b/js/components-chosa.jsx
@@ -5,7 +5,7 @@ import { HOLD_ITEMS, LOCATION_DATA } from './data-items.js';
 import { Panel, PokemonSearch, MoveRow, VerBadge, tmItemName } from './components-base.jsx';
 import { natLabel } from './components-ikusei.jsx';
 
-export const IVChecker = React.memo(function IVChecker({ color, ivs, onSave }) {
+export const IVChecker = React.memo(function IVChecker({ color, ivs, onSave, party, onAddToParty }) {
   const [open,   setOpen]   = useState(false);
   const [mon,    setMon]    = useState(0);
   const [lvStr,  setLvStr]  = useState("50");
@@ -137,6 +137,34 @@ export const IVChecker = React.memo(function IVChecker({ color, ivs, onSave }) {
             }}
           >✅ 全ステータスの個体値を登録</button>
         ) : null;
+      })()}
+      {onAddToParty && (() => {
+        const name = POKEMON_DATA[mon][1];
+        const alreadyIn = party && party.find(p => p.name === name);
+        if (alreadyIn) return (
+          <div style={{ fontSize: "10px", color: "#555", textAlign: "center", marginTop: "6px" }}>
+            ✅ {name} は育成パーティに登録済み
+          </div>
+        );
+        const ivsToRegister = Object.fromEntries(
+          STATS.map(s => {
+            const r = calcIV(s.key);
+            if (r && r.length === 1) return [s.key, r[0]];
+            if (r && r.length > 1)  return [s.key, Math.round((r[0] + r[r.length - 1]) / 2)];
+            return [s.key, 15];
+          })
+        );
+        return (
+          <button
+            onClick={() => onAddToParty(name, mon, ivsToRegister, NATURES[nat].name)}
+            style={{
+              width: "100%", marginTop: "6px", background: "#1a1a3a",
+              border: `1px solid ${color}55`, borderRadius: "6px",
+              color: color, fontSize: "11px", padding: "7px", cursor: "pointer",
+              fontFamily: "inherit", letterSpacing: "1px",
+            }}
+          >＋ 育成パーティに追加</button>
+        );
       })()}
       <div style={{ fontSize: "8px", color: "#333", marginTop: "6px" }}>「？」は実数値・努力値・レベルを確認　各値クリックで個別登録</div>
     </Panel>
@@ -859,14 +887,14 @@ export const AbilitySearch = React.memo(function AbilitySearch({ color }) {
 });
 
 
-export default function ChosaTab({ color, party, allIVs, dexTarget, onDexTargetConsumed, macho, ivs, onSave }) {
+export default function ChosaTab({ color, party, allIVs, dexTarget, onDexTargetConsumed, macho, ivs, onSave, onAddToParty }) {
   return (
     <>
       <IVCompare party={party} allIVs={allIVs} color={color} />
       <PokedexPanel color={color} dexTarget={dexTarget} onDexTargetConsumed={onDexTargetConsumed} />
       <TypeChart color={color} />
       <LocationGuide color={color} />
-      <IVChecker color={color} ivs={ivs} onSave={onSave} />
+      <IVChecker color={color} ivs={ivs} onSave={onSave} party={party} onAddToParty={onAddToParty} />
       <AbilitySearch color={color} />
       <EVSearch macho={macho} color={color} />
       <MoveTutorPanel color={color} />

--- a/js/tracker.jsx
+++ b/js/tracker.jsx
@@ -438,6 +438,16 @@ export default function EVTracker() {
     setNewDexId(null);
   }, [newName, newIcon, newColor, newDexId, party]);
 
+  const addMonFromChosa = useCallback((name, dexId, ivsObj, natureName) => {
+    if (!name || party.find(p => p.name === name)) return;
+    setParty(prev => [...prev, { name, icon: "❓", color: "#888888", memo: "", nature: natureName || "", dexId }]);
+    setAllEVs(prev => ({ ...prev, [name]: initEVs() }));
+    setAllIVs(prev => ({ ...prev, [name]: ivsObj }));
+    setAllMoves(prev => ({ ...prev, [name]: ["","","",""] }));
+    setSelected(name);
+    navigateTab("ikusei");
+  }, [party, navigateTab]);
+
   const learnableMoves = useMemo(() => {
     const pd = mon.dexId != null ? POKEMON_DATA[mon.dexId] : null;
     return pd ? getLearnableMoves(pd[0]) : ALL_MOVES;
@@ -724,6 +734,7 @@ export default function EVTracker() {
                 macho={macho}
                 ivs={allIVs[selected] || initIVs()}
                 onSave={saveIVs}
+                onAddToParty={addMonFromChosa}
               />
             </React.Suspense>
           )}


### PR DESCRIPTION
## Summary

- 調査タブの個体値チェッカーに「＋ 育成パーティに追加」ボタンを追加
- 確定した個体値・範囲の中央値・性格をそのまま引き継いでパーティ登録
- 登録後、育成タブに自動遷移して登録したポケモンが選択済み状態になる
- 既にパーティ登録済みの場合は「登録済み」テキスト表示

Closes #24

## Test plan

- [ ] 調査タブ → 個体値チェッカーでポケモンを選択し、「＋ 育成パーティに追加」が表示される
- [ ] ボタンタップ後、育成タブに遷移し新ポケモンが選択済みになる
- [ ] 引き継がれた個体値・性格が正しく設定されている
- [ ] 未入力の個体値は中央値（15）、範囲の場合は中央値で登録される
- [ ] 同じポケモンで再度チェッカーを開くと「登録済み」表示になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)