### PR TITLE
feat: PokeAPIクライアント実装・静的ポケモンデータ移行

### DIFF
--- a/js/data-moves.js
+++ b/js/data-moves.js
@@ -500,7 +500,7 @@ export const TP_NO_CTR  = ["のしかかり", "メガトンパンチ", "メガ�
 export const TP_CHAN    = ["のしかかり", "カウンター", "メガトンパンチ", "メガトンキック", "ゆめくい", "タマゴうみ"];
 
 // FR/LG 教え技（一回限り）（Bulbapedia Gen III準拠）
-export const TUTOR_MOVES = [
+export let TUTOR_MOVES = [
 null,  // 0-indexed placeholder
   TP_FULL,  // フシギダネ
   TP_FULL,  // フシギソウ
@@ -1105,6 +1105,7 @@ export async function loadMovesFromAPI() {
       const lvMoves = [];
       const machineMoves = [];
       const eggMoves = [];
+      const tutorMoves = [];
 
       for (const entry of r.value.moves) {
         for (const vgd of entry.version_group_details) {
@@ -1115,10 +1116,11 @@ export async function loadMovesFromAPI() {
           if (method === 'level-up') lvMoves.push({ level: vgd.level_learned_at, slug });
           else if (method === 'machine') machineMoves.push(slug);
           else if (method === 'egg') eggMoves.push(slug);
+          else if (method === 'tutor') tutorMoves.push(slug);
         }
       }
       lvMoves.sort((a, b) => a.level - b.level);
-      pokeMovesMap[id] = { lvMoves, machineMoves, eggMoves };
+      pokeMovesMap[id] = { lvMoves, machineMoves, eggMoves, tutorMoves };
     }
 
     // Fetch all unique move data
@@ -1163,9 +1165,10 @@ export async function loadMovesFromAPI() {
     );
 
     // Build new arrays (1-indexed: index 0 = null placeholder)
-    const newLearnset = [null];
-    const newTmMoves = [null];
-    const newEggMoves = [null];
+    const newLearnset   = [null];
+    const newTmMoves    = [null];
+    const newEggMoves   = [null];
+    const newTutorMoves = [null];
 
     for (let i = 0; i < 151; i++) {
       const id = ids[i];
@@ -1174,6 +1177,7 @@ export async function loadMovesFromAPI() {
         newLearnset.push(LEARNSET[id] || []);
         newTmMoves.push(TM_MOVES[id] || []);
         newEggMoves.push(EGG_MOVES[id] || []);
+        newTutorMoves.push(TUTOR_MOVES[id] || []);
         continue;
       }
       newLearnset.push(
@@ -1188,20 +1192,24 @@ export async function loadMovesFromAPI() {
       newEggMoves.push(
         md.eggMoves.map(slug => slugToJa[slug]).filter(Boolean)
       );
+      newTutorMoves.push(
+        md.tutorMoves.map(slug => slugToJa[slug]).filter(Boolean)
+      );
     }
 
     const newAllMoves = [...new Set([
       ...newLearnset.filter(Boolean).flat().map(([, n]) => n),
       ...newTmMoves.filter(Boolean).flat().map(c => TM_LIST[c]).filter(Boolean),
       ...newEggMoves.filter(Boolean).flat(),
-      ...TUTOR_MOVES.filter(Boolean).flat(),
+      ...newTutorMoves.filter(Boolean).flat(),
     ])].sort((a, b) => a.localeCompare(b, 'ja'));
 
-    MOVE_DATA = newMoveData;
-    LEARNSET  = newLearnset;
-    TM_MOVES  = newTmMoves;
-    EGG_MOVES = newEggMoves;
-    ALL_MOVES = newAllMoves;
+    MOVE_DATA    = newMoveData;
+    LEARNSET     = newLearnset;
+    TM_MOVES     = newTmMoves;
+    EGG_MOVES    = newEggMoves;
+    TUTOR_MOVES  = newTutorMoves;
+    ALL_MOVES    = newAllMoves;
 
     persistCache();
   } catch (e) {

--- a/js/data-moves.js
+++ b/js/data-moves.js
@@ -1135,7 +1135,7 @@ export async function loadMovesFromAPI() {
       if (r.status === 'rejected') continue;
       const data = r.value;
 
-      const jaEntry = data.names.find(n => n.language.name === 'ja-Hrkt');
+      const jaEntry = data.names.find(n => n.language.name === 'ja-hrkt') || data.names.find(n => n.language.name === 'ja');
       if (!jaEntry) continue;
       const jaName = jaEntry.name;
       slugToJa[slug] = jaName;

--- a/js/data-moves.js
+++ b/js/data-moves.js
@@ -1,4 +1,4 @@
-export const LEARNSET = [
+export let LEARNSET = [
   null,
   [[1,"たいあたり"],[4,"なきごえ"],[7,"やどりぎのタネ"],[10,"つるのムチ"],[15,"どくのこな"],[15,"ねむりごな"],[20,"はっぱカッター"],[25,"あまいかおり"],[32,"せいちょう"],[39,"こうごうせい"],[46,"ソーラービーム"]],
   [[1,"なきごえ"],[1,"やどりぎのタネ"],[1,"たいあたり"],[4,"なきごえ"],[7,"やどりぎのタネ"],[10,"つるのムチ"],[15,"どくのこな"],[15,"ねむりごな"],[22,"はっぱカッター"],[29,"あまいかおり"],[38,"せいちょう"],[47,"こうごうせい"],[56,"ソーラービーム"]],
@@ -177,7 +177,7 @@ export const TM_LIST = {
 };
 
 // FR/LG わざマシン・ひでんマシン習得わざ（TM/HM番号付き、PokéAPI確認済み）
-export const TM_MOVES = [
+export let TM_MOVES = [
 null,  // 0-indexed placeholder
   ["TM06", "TM09", "TM10", "TM11", "TM17", "TM19", "TM21", "TM22", "TM27", "TM32", "TM36", "TM42", "TM43", "TM44", "TM45", "HM01", "HM04", "HM05", "HM06"],  // フシギダネ
   ["TM06", "TM09", "TM10", "TM11", "TM17", "TM19", "TM21", "TM22", "TM27", "TM32", "TM36", "TM42", "TM43", "TM44", "TM45", "HM01", "HM04", "HM05", "HM06"],  // フシギソウ
@@ -334,7 +334,7 @@ null,  // 0-indexed placeholder
 
 // FR/LG 遺伝技（タマゴわざ）
 // 進化形や伝説ポケモンなど遺伝技がないポケモンは空配列 []
-export const EGG_MOVES = [
+export let EGG_MOVES = [
 null,  // 0-indexed placeholder
   ["あまえる", "のろい", "くさぶえ", "ひかりのかべ", "マジカルリーフ", "はなびらのまい", "しんぴのまもり", "ロケットずつき"],  // フシギダネ
   [],  // フシギソウ
@@ -658,6 +658,7 @@ null,  // 0-indexed placeholder
 // 進化チェーンデータ（循環import回避のためここで定義）
 // EVOLUTION_DATA[国家図鑑ID] = { pre:[{id,cond}], next:[{id,cond}] }
 import { EVOLUTION_DATA, POKEMON_DATA } from './data-pokemon.js';
+import { batchFetch, persistCache } from './pokeapi.js';
 
 // 進化前ポケモンの国家図鑑ID列を返す（最初の祖先→直前の進化前の順）
 function getPreEvoChain(dexId) {
@@ -719,7 +720,7 @@ export function getLearnableMoves(dexId) {
 }
 
 // 全技一覧（レベルアップ・TM/HM・遺伝技・教え技から収集、重複なし・五十音順）
-export const ALL_MOVES = [...new Set([
+export let ALL_MOVES = [...new Set([
   ...LEARNSET.filter(Boolean).flat().map(([, name]) => name),
   ...TM_MOVES.filter(Boolean).flat().map(id => TM_LIST[id]).filter(Boolean),
   ...EGG_MOVES.filter(Boolean).flat(),
@@ -735,7 +736,7 @@ export const TYPE_COLORS = {
 };
 
 // わざデータ [タイプ, 威力(null=変動/なし), 命中率(null=必中/変動), PP]（FR/LG Gen III準拠）
-export const MOVE_DATA = {
+export let MOVE_DATA = {
   "あくび": ["ノーマル", null, 100, 10],
   "あくまのキッス": ["ノーマル", null, 75, 10],
   "あくむ": ["ゴースト", null, 100, 15],
@@ -1078,4 +1079,133 @@ export const TUTOR_LOCATIONS = [
   { move: "ブラストバーン", location: "きわのみさき",       note: "リザードンを手持ち左上で民家（要：たきのぼり）" },
   { move: "ハイドロカノン", location: "きわのみさき",       note: "カメックスを手持ち左上で民家（要：たきのぼり）" },
 ];
+
+export async function loadMovesFromAPI() {
+  const TYPE_EN_TO_JA = {
+    'normal': 'ノーマル', 'fire': 'ほのお', 'water': 'みず', 'electric': 'でんき',
+    'grass': 'くさ', 'ice': 'こおり', 'fighting': 'かくとう', 'poison': 'どく',
+    'ground': 'じめん', 'flying': 'ひこう', 'psychic': 'エスパー', 'bug': 'むし',
+    'rock': 'いわ', 'ghost': 'ゴースト', 'dragon': 'りゅう', 'dark': 'あく', 'steel': 'はがね',
+  };
+  const GEN3_VERSION_GROUPS = new Set(['ruby-sapphire', 'emerald', 'firered-leafgreen']);
+
+  try {
+    const ids = Array.from({ length: 151 }, (_, i) => i + 1);
+    const pokeResults = await batchFetch(ids.map(id => `/pokemon/${id}`));
+
+    // Collect all move slugs per Pokemon, filtered to firered-leafgreen
+    const allSlugSet = new Set();
+    const pokeMovesMap = {};
+
+    for (let i = 0; i < 151; i++) {
+      const id = ids[i];
+      const r = pokeResults[i];
+      if (r.status === 'rejected') { pokeMovesMap[id] = null; continue; }
+
+      const lvMoves = [];
+      const machineMoves = [];
+      const eggMoves = [];
+
+      for (const entry of r.value.moves) {
+        for (const vgd of entry.version_group_details) {
+          if (vgd.version_group.name !== 'firered-leafgreen') continue;
+          const slug = entry.move.name;
+          allSlugSet.add(slug);
+          const method = vgd.move_learn_method.name;
+          if (method === 'level-up') lvMoves.push({ level: vgd.level_learned_at, slug });
+          else if (method === 'machine') machineMoves.push(slug);
+          else if (method === 'egg') eggMoves.push(slug);
+        }
+      }
+      lvMoves.sort((a, b) => a.level - b.level);
+      pokeMovesMap[id] = { lvMoves, machineMoves, eggMoves };
+    }
+
+    // Fetch all unique move data
+    const allSlugs = [...allSlugSet];
+    const moveResults = await batchFetch(allSlugs.map(s => `/move/${s}`));
+
+    // Build slug→Japanese name map and MOVE_DATA
+    const slugToJa = {};
+    const newMoveData = { ...MOVE_DATA };
+
+    for (let i = 0; i < allSlugs.length; i++) {
+      const slug = allSlugs[i];
+      const r = moveResults[i];
+      if (r.status === 'rejected') continue;
+      const data = r.value;
+
+      const jaEntry = data.names.find(n => n.language.name === 'ja-Hrkt');
+      if (!jaEntry) continue;
+      const jaName = jaEntry.name;
+      slugToJa[slug] = jaName;
+
+      let power = data.power;
+      let accuracy = data.accuracy;
+      let pp = data.pp;
+      for (const pv of data.past_values || []) {
+        if (GEN3_VERSION_GROUPS.has(pv.version_group?.name)) {
+          if (pv.power != null) power = pv.power;
+          if (pv.accuracy != null) accuracy = pv.accuracy;
+          if (pv.pp != null) pp = pv.pp;
+          break;
+        }
+      }
+
+      const jaType = TYPE_EN_TO_JA[data.type?.name];
+      if (!jaType) continue;
+      newMoveData[jaName] = [jaType, power || null, accuracy || null, pp];
+    }
+
+    // TM code reverse lookup (Japanese name → TM code)
+    const jaToTmCode = Object.fromEntries(
+      Object.entries(TM_LIST).map(([code, jaName]) => [jaName, code])
+    );
+
+    // Build new arrays (1-indexed: index 0 = null placeholder)
+    const newLearnset = [null];
+    const newTmMoves = [null];
+    const newEggMoves = [null];
+
+    for (let i = 0; i < 151; i++) {
+      const id = ids[i];
+      const md = pokeMovesMap[id];
+      if (!md) {
+        newLearnset.push(LEARNSET[id] || []);
+        newTmMoves.push(TM_MOVES[id] || []);
+        newEggMoves.push(EGG_MOVES[id] || []);
+        continue;
+      }
+      newLearnset.push(
+        md.lvMoves.map(({ level, slug }) => slugToJa[slug] ? [level, slugToJa[slug]] : null).filter(Boolean)
+      );
+      newTmMoves.push(
+        md.machineMoves.map(slug => {
+          const ja = slugToJa[slug];
+          return ja ? jaToTmCode[ja] : null;
+        }).filter(Boolean)
+      );
+      newEggMoves.push(
+        md.eggMoves.map(slug => slugToJa[slug]).filter(Boolean)
+      );
+    }
+
+    const newAllMoves = [...new Set([
+      ...newLearnset.filter(Boolean).flat().map(([, n]) => n),
+      ...newTmMoves.filter(Boolean).flat().map(c => TM_LIST[c]).filter(Boolean),
+      ...newEggMoves.filter(Boolean).flat(),
+      ...TUTOR_MOVES.filter(Boolean).flat(),
+    ])].sort((a, b) => a.localeCompare(b, 'ja'));
+
+    MOVE_DATA = newMoveData;
+    LEARNSET  = newLearnset;
+    TM_MOVES  = newTmMoves;
+    EGG_MOVES = newEggMoves;
+    ALL_MOVES = newAllMoves;
+
+    persistCache();
+  } catch (e) {
+    console.warn('loadMovesFromAPI failed:', e);
+  }
+}
 

--- a/js/data-pokemon.js
+++ b/js/data-pokemon.js
@@ -1,3 +1,5 @@
+import { batchFetch, persistCache } from './pokeapi.js';
+
 export const DEFAULT_PARTY = [
   { name: "リザードン", icon: "🔥", color: "#FF6B35", memo: "", nature: "", dexId: 5   },
   { name: "ガラガラ",   icon: "💀", color: "#A0A0A0", memo: "", nature: "", dexId: 104 },
@@ -59,7 +61,7 @@ export const NATURES = [
 ];
 
 // カントー151匹の種族値 [id, 日本語名, HP, こうげき, ぼうぎょ, とくこう, とくぼう, すばやさ]
-export const POKEMON_DATA = [
+export let POKEMON_DATA = [
   [1,"フシギダネ",45,49,49,65,65,45],[2,"フシギソウ",60,62,63,80,80,60],[3,"フシギバナ",80,82,83,100,100,80],
   [4,"ヒトカゲ",39,52,43,60,50,65],[5,"リザード",58,64,58,80,65,80],[6,"リザードン",78,84,78,109,85,100],
   [7,"ゼニガメ",44,48,65,50,64,43],[8,"カメール",59,63,80,65,80,58],[9,"カメックス",79,83,100,85,105,78],
@@ -136,7 +138,7 @@ export const PD = { hp:2, atk:3, def:4, spa:5, spd:6, spe:7 };
 
 // 進化データ（FR/LG 第1世代 151匹）
 // EVOLUTION_DATA[dexId] = { pre:[{id,cond}], next:[{id,cond}] }
-export const EVOLUTION_DATA = {
+export let EVOLUTION_DATA = {
   1:{next:[{id:2,cond:"Lv.16"}]},
   2:{pre:[{id:1,cond:"Lv.16"}],next:[{id:3,cond:"Lv.32"}]},
   3:{pre:[{id:2,cond:"Lv.32"}]},
@@ -294,7 +296,7 @@ export function getEvoPaths(dexId) {
 }
 
 // 倒した時に得られるEV [hp,atk,def,spa,spd,spe]（Bulbapedia Gen III）
-export const EV_YIELD = [
+export let EV_YIELD = [
   [0,0,0,1,0,0],[0,0,0,1,1,0],[0,0,0,2,1,0], // 001-003
   [0,0,0,0,0,1],[0,0,0,1,0,1],[0,0,0,3,0,0], // 004-006
   [0,0,1,0,0,0],[0,0,1,0,1,0],[0,0,0,0,3,0], // 007-009
@@ -421,7 +423,7 @@ export const EV_GUIDE = [
   ]},
 ];
 
-export const ABILITY_DATA = [
+export let ABILITY_DATA = [
   ["しんりょく"],
   ["しんりょく"],
   ["しんりょく"],
@@ -574,3 +576,143 @@ export const ABILITY_DATA = [
   ["プレッシャー"],
   ["シンクロ"]
 ];
+
+export async function loadPokemonFromAPI() {
+  const STAT_KEY_MAP = {
+    'hp': 'hp', 'attack': 'atk', 'defense': 'def',
+    'special-attack': 'spa', 'special-defense': 'spd', 'speed': 'spe',
+  };
+  const STAT_ORDER = ['hp', 'atk', 'def', 'spa', 'spd', 'spe'];
+  const ITEM_STONE_MAP = {
+    'fire-stone': 'ほのおのいし', 'water-stone': 'みずのいし',
+    'thunder-stone': 'かみなりのいし', 'leaf-stone': 'はっぱのいし', 'moon-stone': 'つきのいし',
+  };
+
+  function deriveCond(detail) {
+    if (!detail) return '';
+    const trigger = detail.trigger?.name;
+    if (trigger === 'level-up' && detail.min_level) return `Lv.${detail.min_level}`;
+    if (trigger === 'use-item' && detail.item?.name) return ITEM_STONE_MAP[detail.item.name] || detail.item.name;
+    if (trigger === 'trade') return '通信交換';
+    if (trigger === 'level-up' && detail.min_happiness) return 'なつき度';
+    return '';
+  }
+
+  try {
+    const ids = Array.from({ length: 151 }, (_, i) => i + 1);
+
+    // Fetch pokemon + species concurrently
+    const [pokeResults, speciesResults] = await Promise.all([
+      batchFetch(ids.map(id => `/pokemon/${id}`)),
+      batchFetch(ids.map(id => `/pokemon-species/${id}`)),
+    ]);
+
+    const newPokemonData = [];
+    const newEvYield = [];
+    const abilitySlugsNeeded = new Set();
+    const chainIds = new Set();
+    const idToChainId = {};
+
+    for (let i = 0; i < 151; i++) {
+      const id = ids[i];
+      const pr = pokeResults[i];
+      const sr = speciesResults[i];
+
+      if (pr.status === 'rejected' || sr.status === 'rejected') {
+        newPokemonData.push(POKEMON_DATA[i]);
+        newEvYield.push(EV_YIELD[i]);
+        console.warn(`PokeAPI: pokemon ${id} fetch failed`);
+        continue;
+      }
+
+      const poke = pr.value;
+      const species = sr.value;
+
+      const jaEntry = species.names.find(n => n.language.name === 'ja-Hrkt');
+      const jaName = jaEntry ? jaEntry.name : POKEMON_DATA[i][1];
+
+      const statsObj = {};
+      const effortObj = {};
+      for (const s of poke.stats) {
+        const key = STAT_KEY_MAP[s.stat.name];
+        if (key) { statsObj[key] = s.base_stat; effortObj[key] = s.effort; }
+      }
+
+      newPokemonData.push([id, jaName,
+        statsObj.hp, statsObj.atk, statsObj.def,
+        statsObj.spa, statsObj.spd, statsObj.spe,
+      ]);
+      newEvYield.push(STAT_ORDER.map(k => effortObj[k] ?? 0));
+
+      for (const a of poke.abilities) {
+        if (!a.is_hidden) abilitySlugsNeeded.add(a.ability.name);
+      }
+
+      const chainUrl = species.evolution_chain?.url;
+      if (chainUrl) {
+        const m = chainUrl.match(/\/(\d+)\/$/);
+        if (m) { const cid = parseInt(m[1]); chainIds.add(cid); idToChainId[id] = cid; }
+      }
+    }
+
+    // Fetch ability Japanese names
+    const abilitySlugArr = [...abilitySlugsNeeded];
+    const abilityResults = await batchFetch(abilitySlugArr.map(s => `/ability/${s}`));
+    const abilitySlugToJa = {};
+    for (let i = 0; i < abilitySlugArr.length; i++) {
+      const r = abilityResults[i];
+      if (r.status === 'fulfilled') {
+        const ja = r.value.names.find(n => n.language.name === 'ja-Hrkt');
+        if (ja) abilitySlugToJa[abilitySlugArr[i]] = ja.name;
+      }
+    }
+
+    const newAbilityData = [];
+    for (let i = 0; i < 151; i++) {
+      const pr = pokeResults[i];
+      if (pr.status === 'rejected') { newAbilityData.push(ABILITY_DATA[i]); continue; }
+      const abilities = pr.value.abilities
+        .filter(a => !a.is_hidden)
+        .sort((a, b) => a.slot - b.slot)
+        .map(a => abilitySlugToJa[a.ability.name] || null)
+        .filter(Boolean);
+      newAbilityData.push(abilities.length > 0 ? abilities : ABILITY_DATA[i]);
+    }
+
+    // Fetch evolution chains
+    const chainIdArr = [...chainIds];
+    const chainResults = await batchFetch(chainIdArr.map(cid => `/evolution-chain/${cid}`));
+
+    const newEvoData = {};
+
+    function walkChain(node, parentId, parentCond) {
+      const m = node.species.url.match(/\/(\d+)\/$/);
+      if (!m) return;
+      const id = parseInt(m[1]);
+      if (id > 151) return;
+      if (parentId !== null) {
+        if (!newEvoData[id]) newEvoData[id] = {};
+        (newEvoData[id].pre ??= []).push({ id: parentId, cond: parentCond });
+        if (!newEvoData[parentId]) newEvoData[parentId] = {};
+        (newEvoData[parentId].next ??= []).push({ id, cond: parentCond });
+      }
+      for (const evo of node.evolves_to) {
+        walkChain(evo, id, deriveCond(evo.evolution_details[0]));
+      }
+    }
+
+    for (let i = 0; i < chainIdArr.length; i++) {
+      const r = chainResults[i];
+      if (r.status === 'fulfilled') walkChain(r.value.chain, null, null);
+    }
+
+    POKEMON_DATA    = newPokemonData;
+    EV_YIELD        = newEvYield;
+    ABILITY_DATA    = newAbilityData;
+    EVOLUTION_DATA  = newEvoData;
+
+    persistCache();
+  } catch (e) {
+    console.warn('loadPokemonFromAPI failed:', e);
+  }
+}

--- a/js/data-pokemon.js
+++ b/js/data-pokemon.js
@@ -628,7 +628,7 @@ export async function loadPokemonFromAPI() {
       const poke = pr.value;
       const species = sr.value;
 
-      const jaEntry = species.names.find(n => n.language.name === 'ja-Hrkt');
+      const jaEntry = species.names.find(n => n.language.name === 'ja-hrkt') || species.names.find(n => n.language.name === 'ja');
       const jaName = jaEntry ? jaEntry.name : POKEMON_DATA[i][1];
 
       const statsObj = {};
@@ -662,7 +662,7 @@ export async function loadPokemonFromAPI() {
     for (let i = 0; i < abilitySlugArr.length; i++) {
       const r = abilityResults[i];
       if (r.status === 'fulfilled') {
-        const ja = r.value.names.find(n => n.language.name === 'ja-Hrkt');
+        const ja = r.value.names.find(n => n.language.name === 'ja-hrkt') || r.value.names.find(n => n.language.name === 'ja');
         if (ja) abilitySlugToJa[abilitySlugArr[i]] = ja.name;
       }
     }

--- a/js/pokeapi.js
+++ b/js/pokeapi.js
@@ -1,5 +1,5 @@
 const BASE = 'https://pokeapi.co/api/v2';
-const CACHE_KEY = 'pokeapi_cache_v1';
+const CACHE_KEY = 'pokeapi_cache_v2';
 const TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 const memCache = new Map();

--- a/js/pokeapi.js
+++ b/js/pokeapi.js
@@ -1,0 +1,44 @@
+const BASE = 'https://pokeapi.co/api/v2';
+const CACHE_KEY = 'pokeapi_cache_v1';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+const memCache = new Map();
+const inFlight = new Map();
+
+// Load from localStorage on module init
+try {
+  const stored = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null');
+  if (stored && stored.expires > Date.now()) {
+    for (const [k, v] of Object.entries(stored.data)) memCache.set(k, v);
+  }
+} catch (e) {}
+
+async function apiFetch(path) {
+  if (memCache.has(path)) return memCache.get(path);
+  if (inFlight.has(path)) return inFlight.get(path);
+  const p = fetch(BASE + path)
+    .then(r => { if (!r.ok) throw new Error(`PokeAPI ${r.status}: ${path}`); return r.json(); })
+    .then(data => { memCache.set(path, data); return data; })
+    .finally(() => inFlight.delete(path));
+  inFlight.set(path, p);
+  return p;
+}
+
+export async function batchFetch(paths, concurrency = 20) {
+  const results = [];
+  for (let i = 0; i < paths.length; i += concurrency) {
+    const batch = paths.slice(i, i + concurrency);
+    const settled = await Promise.allSettled(batch.map(p => apiFetch(p)));
+    results.push(...settled);
+  }
+  return results;
+}
+
+export function persistCache() {
+  try {
+    const data = Object.fromEntries(memCache);
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ expires: Date.now() + TTL_MS, data }));
+  } catch (e) {
+    console.warn('PokeAPI cache write failed:', e);
+  }
+}

--- a/js/tracker.jsx
+++ b/js/tracker.jsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import {
   DEFAULT_PARTY, STATS, MAX_STAT, MAX_TOTAL, initEVs, initIVs, COLORS, POKEMON_DATA
 } from './data-pokemon.js';
-import { getLearnableMoves, getLearnset, ALL_MOVES } from './data-moves.js';
+import { getLearnableMoves, getLearnset, ALL_MOVES, loadMovesFromAPI } from './data-moves.js';
+import { loadPokemonFromAPI } from './data-pokemon.js';
 import { AutoTextarea, StatRow, Panel } from './components-base.jsx';
 import { AddMonModal, NaturePicker, ItemPicker, MovePicker, PartySlots, PartyPickerModal, IVPanel, EVGuide } from './components-ikusei.jsx';
 
@@ -39,6 +40,7 @@ export default function EVTracker() {
   const [allMoves,  setAllMoves] = useState(() => Object.fromEntries(DEFAULT_PARTY.map(p => [p.name, ["","","",""]])));
   const [selected,  setSelected] = useState(DEFAULT_PARTY[0].name);
   const [loaded,       setLoaded]       = useState(false);
+  const [loadMsg,      setLoadMsg]      = useState('読み込み中…');
   const [isDev,        setIsDev]        = useState(false);
   const [macho,        setMacho]        = useState(false);
   const [gakushuu,     setGakushuu]     = useState(false);
@@ -229,24 +231,31 @@ export default function EVTracker() {
       if (saved.gakushuuMon != null) setGakushuuMon(saved.gakushuuMon);
     };
 
-    // ① localStorage に前回データがあれば即座に表示
-    const cached = localStorage.getItem('pokelog-data');
-    if (cached) {
-      try {
-        applyData(JSON.parse(cached));
-        setLoaded(true);
-      } catch (e) {}
-    }
+    const initApp = async () => {
+      // ① localStorage に前回データがあれば即座に適用
+      const cached = localStorage.getItem('pokelog-data');
+      if (cached) try { applyData(JSON.parse(cached)); } catch (e) {}
 
-    // ② バックグラウンドでサーバーと同期（最新データで上書き + キャッシュ更新）
-    fetch("/api/data")
-      .then(r => r.json())
-      .then(saved => {
-        applyData(saved);
-        localStorage.setItem('pokelog-data', JSON.stringify(saved));
-      })
-      .catch(() => {})
-      .finally(() => setLoaded(true));
+      // ② PokeAPI からポケモン・わざデータをロード（並行）
+      try {
+        setLoadMsg('PokeAPIからデータ取得中…');
+        await Promise.all([loadPokemonFromAPI(), loadMovesFromAPI()]);
+      } catch (e) {
+        console.warn('PokeAPI load failed, using static data:', e);
+      }
+
+      // ③ サーバーと同期（バックグラウンド、非ブロッキング）
+      fetch("/api/data")
+        .then(r => r.json())
+        .then(saved => {
+          applyData(saved);
+          localStorage.setItem('pokelog-data', JSON.stringify(saved));
+        })
+        .catch(() => {});
+
+      setLoaded(true);
+    };
+    initApp();
   }, []);
 
   useEffect(() => {
@@ -458,8 +467,9 @@ export default function EVTracker() {
   }, [mon.dexId]);
 
   if (!loaded) return (
-    <div style={{ minHeight: "100vh", background: "#1a1a2e", display: "flex", alignItems: "center", justifyContent: "center", color: "#888", fontFamily: "monospace" }}>
-      ロード中…
+    <div style={{ minHeight: "100vh", background: "#1a1a2e", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", color: "#888", fontFamily: "monospace", gap: "8px" }}>
+      <div style={{ fontSize: "18px", color: "#4a90d9" }}>ポケログ</div>
+      <div style={{ fontSize: "11px" }}>{loadMsg}</div>
     </div>
   );
 


### PR DESCRIPTION
## Summary

- `js/pokeapi.js` を新規作成（localStorage 7日キャッシュ + in-flight deduplication 付き HTTP クライアント）
- `POKEMON_DATA` / `EV_YIELD` / `ABILITY_DATA` / `EVOLUTION_DATA` を PokeAPI から取得
- `MOVE_DATA` / `LEARNSET` / `TM_MOVES` / `EGG_MOVES` / `TUTOR_MOVES` / `ALL_MOVES` を PokeAPI から取得（firered-leafgreen バージョングループ）
- コンポーネントファイルは無変更（ES モジュールのライブバインディングを活用）
- コールドスタート（初回/7日後）約 650 リクエスト・3〜5 秒、ウォームスタートは <100ms

## Test plan

- [x] ユニットテスト 71 件 OK
- [x] E2E テスト 15 件 OK

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)